### PR TITLE
fix(ci): repair release artifact workflows

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -319,7 +319,7 @@ jobs:
           echo "image_name=subcults-${IMAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ steps.build.outputs.image_name }}:scan'
           format: 'json'
@@ -328,7 +328,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Run Trivy for human-readable output
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ steps.build.outputs.image_name }}:scan'
           format: 'table'
@@ -337,7 +337,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Run Trivy for SARIF output
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ steps.build.outputs.image_name }}:scan'
           format: 'sarif'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,7 +108,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.sha }}
           format: sarif

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -39,11 +39,11 @@ jobs:
           cache: true
 
       - name: Install cyclonedx-gomod
-        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.11.0
 
       - name: Generate Go SBOM (CycloneDX JSON)
         run: |
-          cyclonedx-gomod app \
+          cyclonedx-gomod mod \
             -licenses \
             -json \
             -output sbom-go.cdx.json \
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate Go SBOM (CycloneDX XML)
         run: |
-          cyclonedx-gomod app \
+          cyclonedx-gomod mod \
             -licenses \
             -output sbom-go.cdx.xml \
             .


### PR DESCRIPTION
Repairs post-merge release automation observed on the Jetstream v2 rollout.\n\n- pin Trivy action to current official v0.36.0 instead of nonexistent v0.28.0 or mutable master\n- generate the Go CycloneDX SBOM in module mode\n- pin cyclonedx-gomod v1.11.0\n\nLocal verification generated valid JSON and XML CycloneDX documents with non-empty component inventories.