### PR TITLE
fix(ci): publish immutable full-SHA image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
           tags: |
             type=sha,prefix=
+            type=raw,value=${{ github.sha }}
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Summary
- publish each release image under the complete Git commit SHA
- align the build output with the existing Trivy scan input

## Evidence
- release run 31866010892 built and pushed all three images, then every scan failed with MANIFEST_UNKNOWN for the full-SHA tag
- docker/metadata-action's type=sha tag is shortened; the scanner intentionally requests github.sha

## Verification
- git diff --check
- YAML change is limited to one additional raw metadata tag