### PR TITLE
fix(ci): enforce declared Trivy severity gate

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,6 +115,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security


### PR DESCRIPTION
## Summary
- make SARIF generation honor the workflow's CRITICAL,HIGH severity policy
- keep exit-code 1 so any high or critical result still fails publication

## Evidence
- release run 31866205633 successfully scanned the immutable full-SHA images
- Trivy logged that SARIF contained all severities because limit-severities-for-sarif defaults off
- uploaded API/indexer findings are medium or advisory; the frontend scan passed

## Verification
- git diff --check
- one input added to the official Trivy action